### PR TITLE
Add Ingero - GPU observability MCP server for SRE agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,5 @@ A curated list of AI-powered DevOps &amp; SRE (Site Reliability Engineering) age
 - [Resolve AI](https://resolve.ai)
 - [Sherlocks.ai](https://www.sherlocks.ai/)
 - [IncidentFox](https://github.com/incidentfox/incidentfox) (Open Source)
+- [Ingero](https://github.com/ingero-io/ingero) - eBPF-based GPU causal observability agent with MCP server. Enables AI agents (Claude, Cursor) to investigate GPU performance incidents by querying CUDA API traces, causal chains, and host kernel events. (Open Source)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A curated list of AI-powered DevOps &amp; SRE (Site Reliability Engineering) age
 - [RunWhen](https://www.runwhen.com/)
 
 ### SRE Agents
-- [KubeStellar Console](https://github.com/kubestellar/console) - Open source AI-powered multi-cluster Kubernetes dashboard with AI chat for cluster operations, real-time observability, and CNCF integrations (Argo, Kyverno, Prometheus, and 20+ others).
+- [KubeStellar Console](https://github.com/kubestellar/console) (Open Source)
 - [Komodor Klaudia AI](https://komodor.com/)
 - [Agent SRE](https://agentsre.ai/)
 - [Cleric](https://cleric.io/)
@@ -37,5 +37,5 @@ A curated list of AI-powered DevOps &amp; SRE (Site Reliability Engineering) age
 - [IncidentFox](https://github.com/incidentfox/incidentfox) (Open Source)
 - [Open SRE Agent](https://github.com/Tracer-Cloud/open-sre-agent) (Open Source)
 - [Metoro](https://www.metoro.io/) 
-- [Ingero](https://github.com/ingero-io/ingero) - eBPF-based GPU causal observability agent with MCP server. Enables AI agents (Claude, Cursor) to investigate GPU performance incidents by querying CUDA API traces, causal chains, and host kernel events. (Open Source)
+- [Ingero](https://github.com/ingero-io/ingero) (Open Source)
 


### PR DESCRIPTION
## What

Adds [Ingero](https://github.com/ingero-io/ingero) to the SRE Agents section.

## Why

Ingero is an open-source, eBPF-based GPU causal observability agent with a built-in MCP server. It enables AI agents (Claude, Cursor, etc.) to investigate GPU performance incidents by querying:

- **CUDA API traces** — Runtime + Driver API latency (cudaMalloc, cudaLaunchKernel, cuMemcpy, etc.)
- **Causal chains** — automated root cause analysis linking host kernel events (scheduler, I/O, TCP, OOM) to GPU stalls
- **Host kernel events** — sched_switch, block I/O, TCP retransmits, process lifecycle

The MCP server exposes 7 tools that AI agents can call directly, making it a natural fit for the SRE agents list.

Key properties:
- Zero-config, <2% overhead, production-safe (kernel uprobes, not CUPTI)
- Single static Go binary, no dependencies
- Apache 2.0 licensed (eBPF kernel code: GPL-2.0 OR BSD-3-Clause)