### PR TITLE
feat: add KubeStellar Console to SRE Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A curated list of AI-powered DevOps &amp; SRE (Site Reliability Engineering) age
 - [RunWhen](https://www.runwhen.com/)
 
 ### SRE Agents
+- [KubeStellar Console](https://github.com/kubestellar/console) - Open source AI-powered multi-cluster Kubernetes dashboard with AI chat for cluster operations, real-time observability, and CNCF integrations (Argo, Kyverno, Prometheus, and 20+ others).
 - [Komodor Klaudia AI](https://komodor.com/)
 - [Agent SRE](https://agentsre.ai/)
 - [Cleric](https://cleric.io/)


### PR DESCRIPTION
Adds KubeStellar Console — an open-source AI-powered multi-cluster Kubernetes dashboard (CNCF Sandbox) — to SRE Agents. It provides AI chat interface for cluster operations, real-time observability, and integrations with Argo, Kyverno, Prometheus, and 20+ CNCF tools. https://github.com/kubestellar/console