### PR TITLE
Add Not Human Search as an agent benchmark resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A curated list of AI-powered DevOps &amp; SRE (Site Reliability Engineering) age
 
 ### Agent Benchmarks
 [SRE Bench](https://sreben.ch/)
+- [Not Human Search](https://nothumansearch.ai) - Search engine and MCP server that scores websites/APIs by agentic readiness and live-verifies MCP endpoints; useful for checking whether SRE agents can safely call external tools.
 
 
 ### Incident Response Agents
@@ -36,4 +37,3 @@ A curated list of AI-powered DevOps &amp; SRE (Site Reliability Engineering) age
 - [Sherlocks.ai](https://www.sherlocks.ai/)
 - [IncidentFox](https://github.com/incidentfox/incidentfox) (Open Source)
 - [Open SRE Agent](https://github.com/Tracer-Cloud/open-sre-agent) (Open Source)
-


### PR DESCRIPTION
Adds Not Human Search under Agent Benchmarks.

Fit:
- It scores websites and APIs by agentic readiness.
- It exposes an MCP server and live MCP verification, which is useful when SRE/DevOps agents need dependable external tools.

Validation:
- nothumansearch.ai returned HTTP 200.
- The MCP endpoint answered a real tools/list JSON-RPC request.